### PR TITLE
BUGFIX: Add roomId to start quiz event

### DIFF
--- a/src/routes/host/WaitingForQuiz.tsx
+++ b/src/routes/host/WaitingForQuiz.tsx
@@ -34,7 +34,7 @@ export default function WaitingForQuiz() {
 
     const startQuiz = () => {
         // emit start quiz event
-        socket.emit(WS_EVENTS.START_QUIZ);
+        socket.emit(WS_EVENTS.START_QUIZ, roomId);
         // transition to next page
         navigate(`/room/${roomId}/in-progress`);
     }


### PR DESCRIPTION
When the host starts the quiz, the `roomId` is missing from the WS event. This PR updates it so that the BE can update the room state to `ACTIVE` in the DB.