### PR TITLE
Componentized header and added visuals for ShowAnswer

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+
+function Header() {
+  return (
+    <div className="bg-purple-800 min-w-full p-5">
+      <Link to="/" className="text-6xl text-white font-bold">
+        !Toohak
+      </Link>
+    </div>
+  );
+}
+
+export default Header;

--- a/src/components/player/DisplayQuestion.tsx
+++ b/src/components/player/DisplayQuestion.tsx
@@ -3,35 +3,41 @@ import { WS_EVENTS } from "../../socket/events";
 import { state$ } from "../../state";
 
 function DisplayQuestion() {
-    const question = state$.quiz.question.get();
-    const answers = state$.quiz.answers.get();
+  const question = state$.quiz.question.get();
+  const answers = state$.quiz.answers.get();
 
-    const handleSubmitAnswer = (answer: string) => {
-        console.log(`selected answer: ${answer}`);
-        state$.quiz.selectedAnswer.set(answer);
-        state$.quiz.answered.set(true);
-        state$.quiz.waitingForOthers.set(true);
-        state$.quiz.displayQuestion.set(false);
-        // send answer to BE
-        socket.emit(WS_EVENTS.ANSWER_QUESTION, state$.roomId.get(), state$.player.id.get(), answer);
-    }
-
-    return (
-        <div className="flex flex-col gap-4">
-            <h1 className="text-2xl font-bold">Question: {question}</h1>
-            <div className="flex flex-col gap-2">
-                {answers.map((answer, idx) => (
-                    <button
-                        key={idx}
-                        onClick={() => handleSubmitAnswer(answer)}
-                        className="text-lg w-full border-2 border-solid border-purple-600
-                            p-2 hover:bg-purple-600 hover:text-white">
-                        {answer}
-                    </button>
-                ))}
-            </div>
-        </div>
+  const handleSubmitAnswer = (answer: string) => {
+    console.log(`selected answer: ${answer}`);
+    state$.quiz.selectedAnswer.set(answer);
+    state$.quiz.answered.set(true);
+    state$.quiz.waitingForOthers.set(true);
+    state$.quiz.displayQuestion.set(false);
+    // send answer to BE
+    socket.emit(
+      WS_EVENTS.ANSWER_QUESTION,
+      state$.roomId.get(),
+      state$.player.id.get(),
+      answer
     );
+  };
+
+  return (
+    <div className="flex flex-col max-w-3xl gap-4">
+      <h1 className="text-2xl font-bold">Question: {question}</h1>
+      <div className="flex flex-col gap-2">
+        {answers.map((answer, idx) => (
+          <button
+            key={idx}
+            onClick={() => handleSubmitAnswer(answer)}
+            className="text-lg w-full border-2 border-solid border-purple-600
+                            p-2 hover:bg-purple-600 hover:text-white"
+          >
+            {answer}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default DisplayQuestion;

--- a/src/components/player/ShowAnswer.tsx
+++ b/src/components/player/ShowAnswer.tsx
@@ -10,6 +10,8 @@ function ShowAnswer() {
       ) : (
         <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-red-700">
           <div className="text-8xl font-thin text-gray-100">Incorrect.</div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/player/ShowAnswer.tsx
+++ b/src/components/player/ShowAnswer.tsx
@@ -1,16 +1,26 @@
 import { state$ } from "../../state";
 
-function ShowAnswer() {
+type ShowAnswerProps = {
+  correctAnswer: string;
+};
+
+function ShowAnswer({ correctAnswer }: ShowAnswerProps) {
   return (
     <>
       {state$.quiz.isAnswerCorrect.get() ? (
-        <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-green-600">
-          <div className="text-8xl font-thin text-gray-100">Correct!</div>
-        </div>
+        <>
+          <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-green-600">
+            <div className="text-8xl font-thin text-gray-100">Correct!</div>
+          </div>
+          <div>You answered: {correctAnswer}!</div>
+        </>
       ) : (
-        <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-red-700">
-          <div className="text-8xl font-thin text-gray-100">Incorrect.</div>
-        </div>
+        <>
+          <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-red-700">
+            <div className="text-8xl font-thin text-gray-100">Incorrect.</div>
+          </div>
+          <div className="text-3xl">The answer was: {correctAnswer}.</div>
+        </>
       )}
     </>
   );

--- a/src/components/player/ShowAnswer.tsx
+++ b/src/components/player/ShowAnswer.tsx
@@ -1,16 +1,19 @@
 import { state$ } from "../../state";
 
-function ShowAnswer() {    
-    
-    // wait 5 sec
-    // emit WS(waitingforquiz)
-    // navigate to WaitingForNextQuestion
-
-    return (
-        <div>
-            {state$.quiz.isAnswerCorrect.get() ? 'yay you got it right' : 'boo wrong'}
+function ShowAnswer() {
+  return (
+    <>
+      {state$.quiz.isAnswerCorrect.get() ? (
+        <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-green-600">
+          <div className="text-8xl font-thin text-gray-100">Correct!</div>
         </div>
-    );
+      ) : (
+        <div className="w-auto h-auto flex flex-col justify-center items-center p-12 rounded-3xl bg-red-700">
+          <div className="text-8xl font-thin text-gray-100">Incorrect.</div>
+        </div>
+      )}
+    </>
+  );
 }
 
 export default ShowAnswer;

--- a/src/components/player/ShowAnswer.tsx
+++ b/src/components/player/ShowAnswer.tsx
@@ -5,7 +5,7 @@ type ShowAnswerProps = {
 };
 
 function ShowAnswer({ correctAnswer }: ShowAnswerProps) {
-  if (!state$.quiz.isAnswerCorrect.get()) {
+  if (state$.quiz.isAnswerCorrect.get()) {
     return (
       <>
         <div className="absolute top-0 left-0 w-screen h-screen flex flex-col justify-center items-center gap-10 bg-green-600">

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,13 +1,10 @@
 import { Link } from "react-router-dom";
+import Header from "../components/Header";
 
 function LandingPage() {
   return (
     <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-      <div className="bg-purple-800 min-w-full p-5">
-        <Link to="/" className="text-6xl text-white font-bold">
-          !Toohak
-        </Link>
-      </div>
+      <Header />
       <div>
         <p className="text-4xl">Kahoot! but better.</p>
       </div>

--- a/src/routes/host/QuizInProgress.tsx
+++ b/src/routes/host/QuizInProgress.tsx
@@ -1,20 +1,17 @@
-import { Link, useParams } from "react-router-dom"
+import { useParams } from "react-router-dom";
+import Header from "../../components/Header";
 
 export default function QuizInProgress() {
   const { room_id: roomId } = useParams();
   return (
     <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-      <div className="bg-purple-800 min-w-full p-5">
-        <Link to="/" className="text-6xl text-white font-bold">
-          !Toohak
-        </Link>
-      </div>
+      <Header />
       <div className="p-2">
         <h1 className="text-2xl">
-          <span className="font-bold">Room {roomId} Status:</span>&nbsp;
-          Quiz In Progress
+          <span className="font-bold">Room {roomId} Status:</span>&nbsp; Quiz In
+          Progress
         </h1>
       </div>
     </div>
-  )
+  );
 }

--- a/src/routes/host/WaitingForQuiz.tsx
+++ b/src/routes/host/WaitingForQuiz.tsx
@@ -1,73 +1,69 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom";
 import { socket } from "../../socket";
 import { WS_EVENTS } from "../../socket/events";
+import Header from "../../components/Header";
 
 export default function WaitingForQuiz() {
-    const navigate = useNavigate();
-    const { room_id: roomId } = useParams();
-    const origin = window.location.origin;
+  const navigate = useNavigate();
+  const { room_id: roomId } = useParams();
+  const origin = window.location.origin;
 
-    const [players, setPlayers] = useState<string[]>([]);
+  const [players, setPlayers] = useState<string[]>([]);
 
-    // Host joins the websocket room for the quiz
-    useEffect(() => {
-        socket.emit(WS_EVENTS.JOIN_ROOM, roomId);
-    }, [roomId])
+  // Host joins the websocket room for the quiz
+  useEffect(() => {
+    socket.emit(WS_EVENTS.JOIN_ROOM, roomId);
+  }, [roomId]);
 
-    useEffect(() => {
-        // handle new player event
-        const handleNewPlayer = ({ playerId }: { playerId: string }) => {
-            // set state this way to avoid calling this effect again
-            // see https://socket.io/how-to/use-with-react#remarks-about-the-useeffect-hook
-            setPlayers(prevPlayers => [...prevPlayers, playerId]);
-        };
+  useEffect(() => {
+    // handle new player event
+    const handleNewPlayer = ({ playerId }: { playerId: string }) => {
+      // set state this way to avoid calling this effect again
+      // see https://socket.io/how-to/use-with-react#remarks-about-the-useeffect-hook
+      setPlayers((prevPlayers) => [...prevPlayers, playerId]);
+    };
 
-        // listen for new player event
-        socket.on(WS_EVENTS.NEW_PLAYER, handleNewPlayer);
+    // listen for new player event
+    socket.on(WS_EVENTS.NEW_PLAYER, handleNewPlayer);
 
-        // stop listening for event when component is unmounted
-        return () => {
-            socket.off(WS_EVENTS.NEW_PLAYER);
-        }
-    }, []);
+    // stop listening for event when component is unmounted
+    return () => {
+      socket.off(WS_EVENTS.NEW_PLAYER);
+    };
+  }, []);
 
-    const startQuiz = () => {
-        // emit start quiz event
-        socket.emit(WS_EVENTS.START_QUIZ, roomId);
-        // transition to next page
-        navigate(`/room/${roomId}/in-progress`);
-    }
+  const startQuiz = () => {
+    // emit start quiz event
+    socket.emit(WS_EVENTS.START_QUIZ, roomId);
+    // transition to next page
+    navigate(`/room/${roomId}/in-progress`);
+  };
 
-    return (
-        <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-            <div className="bg-purple-800 min-w-full p-5">
-                <Link to="/" className="text-6xl text-white font-bold">
-                    !Toohak
-                </Link>
-            </div>
-            <div className="p-2">
-                <p className="text-3xl font-bold pb-4">Waiting for Quiz to start...</p>
-                <p className="text-2xl">
-                    Go to the following link to join the quiz:&nbsp;
-                    <span className="font-bold">{`${origin}/join/${roomId}`}</span>
-                </p>
-                <div className="mt-4">
-                    <p className="font-bold text-xl">Current Players:</p>
-                    <ul className="list-disc pl-10">
-                        {players.map((player, idx) => {
-                            return (
-                                <li key={idx}>{player}</li>
-                            );
-                        })}
-                    </ul>
-                </div>
-                <button
-                    className="bg-purple-700 hover:bg-purple-500 text-white hover:text-gray-50 p-2 rounded-lg mt-4"
-                    onClick={startQuiz}>
-                    Start Quiz!
-                </button>
-            </div>
+  return (
+    <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
+      <Header />
+      <div className="p-2">
+        <p className="text-3xl font-bold pb-4">Waiting for Quiz to start...</p>
+        <p className="text-2xl">
+          Go to the following link to join the quiz:&nbsp;
+          <span className="font-bold">{`${origin}/join/${roomId}`}</span>
+        </p>
+        <div className="mt-4">
+          <p className="font-bold text-xl">Current Players:</p>
+          <ul className="list-disc pl-10">
+            {players.map((player, idx) => {
+              return <li key={idx}>{player}</li>;
+            })}
+          </ul>
         </div>
-    )
+        <button
+          className="bg-purple-700 hover:bg-purple-500 text-white hover:text-gray-50 p-2 rounded-lg mt-4"
+          onClick={startQuiz}
+        >
+          Start Quiz!
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/routes/player/JoinRoom.tsx
+++ b/src/routes/player/JoinRoom.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { socket } from "../../socket";
 import { WS_EVENTS } from "../../socket/events";
 import { state$ } from "../../state";
+import Header from "../../components/Header";
 
 // generate a random number from 1-1000 and append to string 'player'
 const generatePlayerId = () => `player${Math.floor(Math.random() * 1000) + 1}`;
@@ -26,30 +27,30 @@ function JoinRoom() {
         playerId: state$.player.id.get(),
       });
 
-      const handleNewQuestion = (
-        { question, answers }: { question: string; answers: Array<string> }
-      ) => {
+      const handleNewQuestion = ({
+        question,
+        answers,
+      }: {
+        question: string;
+        answers: Array<string>;
+      }) => {
         // set state
         state$.quiz.question.set(question);
         state$.quiz.answers.set(answers);
         // navigate to play quiz view
         navigate(`/quiz/${roomId}`);
-      }
+      };
       socket.on(WS_EVENTS.NEW_QUESTION, handleNewQuestion);
 
       return () => {
         socket.off(WS_EVENTS.NEW_QUESTION);
-      }
+      };
     }
   }, [roomId, navigate]);
 
   return (
     <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-      <div className="bg-purple-800 min-w-full p-5">
-        <Link to="/" className="text-6xl text-white font-bold">
-          !Toohak
-        </Link>
-      </div>
+      <Header />
       <div className="flex flex-row-reverse w-full gap-3 p-2">
         <p className="text-lg">ID: {state$.player.id.get()}</p>
         <h1 className="flex-1 text-center text-3xl font-bold">

--- a/src/routes/player/PlayQuiz.tsx
+++ b/src/routes/player/PlayQuiz.tsx
@@ -117,11 +117,7 @@ const PlayQuiz = observer(() => {
 
   return (
     <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-      <div className="bg-purple-800 min-w-full p-5">
-        <Link to="/" className="text-6xl text-white font-bold">
-          !Toohak
-        </Link>
-      </div>
+      <Header />
       <div className="flex w-full p-2 justify-end">
         <p className="text-lg">ID: {state$.player.id.get()}</p>
       </div>

--- a/src/routes/player/PlayQuiz.tsx
+++ b/src/routes/player/PlayQuiz.tsx
@@ -58,7 +58,8 @@ const PlayQuiz = observer(() => {
       state$.quiz.displayQuestion.set(false);
       state$.quiz.waitingForOthers.set(false);
       state$.quiz.answered.set(true);
-      console.log("showing answer");
+      console.log("showing answer: " + data.correctAnswer);
+      state$.quiz.correctAnswer.set(data.correctAnswer);
     };
 
     socket.on(WS_EVENTS.SHOW_ANSWER, handleShowAnswer);
@@ -84,7 +85,7 @@ const PlayQuiz = observer(() => {
         {state$.quiz.displayQuestion.get() && <DisplayQuestion />}
         {state$.quiz.waitingForOthers.get() && <WaitingForOtherPlayers />}
         {state$.quiz.answered.get() && !state$.quiz.waitingForOthers.get() && (
-          <ShowAnswer />
+          <ShowAnswer correctAnswer={state$.quiz.correctAnswer.get()} />
         )}
         {!state$.quiz.displayQuestion.get() &&
           !state$.quiz.waitingForOthers.get() &&

--- a/src/routes/player/PlayQuiz.tsx
+++ b/src/routes/player/PlayQuiz.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import DisplayQuestion from "../../components/player/DisplayQuestion";
 import { useEffect } from "react";
 import { socket } from "../../socket";
@@ -8,7 +7,12 @@ import { state$ } from "../../state";
 import ShowAnswer from "../../components/player/ShowAnswer";
 import WaitingForOtherPlayers from "../../components/player/WaitingForOtherPlayers";
 import WaitingForQuestion from "../../components/player/WaitingForQuestion";
-import { observer, useObservable, useObserveEffect } from "@legendapp/state/react";
+import {
+  observer,
+  useObservable,
+  useObserveEffect,
+} from "@legendapp/state/react";
+import Header from "../../components/Header";
 
 // 30 seconds
 const TIMER_DURATION = 30;
@@ -31,69 +35,63 @@ const PlayQuiz = observer(() => {
     const handleStartTimer = () => {
       showTimer.set(true);
       state$.quiz.displayQuestion.set(true);
-      console.log('starting timer now!');
+      console.log("starting timer now!");
       startCountdown();
-    }
+    };
 
     socket.on(WS_EVENTS.START_TIMER, handleStartTimer);
 
     return () => {
       socket.off(WS_EVENTS.START_TIMER);
-    }
+    };
   });
 
-// show answer
-useObserveEffect(() => {
-  const handleShowAnswer = (data: { correctAnswer: string }) => {
-    stopCountdown();
-    showTimer.set(false);
-    console.log(data);
-    const isCorrect = state$.quiz.selectedAnswer.get() === data.correctAnswer;
+  // show answer
+  useObserveEffect(() => {
+    const handleShowAnswer = (data: { correctAnswer: string }) => {
+      stopCountdown();
+      showTimer.set(false);
+      console.log(data);
+      const isCorrect = state$.quiz.selectedAnswer.get() === data.correctAnswer;
 
-    state$.quiz.isAnswerCorrect.set(isCorrect);
-    state$.quiz.displayQuestion.set(false);
-    state$.quiz.waitingForOthers.set(false);
-    state$.quiz.answered.set(true);
-    console.log('showing answer');
-  };
+      state$.quiz.isAnswerCorrect.set(isCorrect);
+      state$.quiz.displayQuestion.set(false);
+      state$.quiz.waitingForOthers.set(false);
+      state$.quiz.answered.set(true);
+      console.log("showing answer");
+    };
 
-  socket.on(WS_EVENTS.SHOW_ANSWER, handleShowAnswer);
+    socket.on(WS_EVENTS.SHOW_ANSWER, handleShowAnswer);
 
-  return () => {
-    socket.off(WS_EVENTS.SHOW_ANSWER, handleShowAnswer);
-  };
-});
+    return () => {
+      socket.off(WS_EVENTS.SHOW_ANSWER, handleShowAnswer);
+    };
+  });
 
-return (
-  <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
-    <div className="bg-purple-800 min-w-full p-5">
-      <Link to="/" className="text-6xl text-white font-bold">
-        !Toohak
-      </Link>
+  return (
+    <div className="bg-gray-100 min-h-screen flex flex-col items-center gap-5">
+      <Header />
+      <div className="flex w-full p-2 justify-end">
+        <p className="text-lg">ID: {state$.player.id.get()}</p>
+      </div>
+      <div className="flex flex-col items-center min-w-full gap-6">
+        {showTimer.get() && (
+          <div className="text-2xl text-center">
+            <span className="font-semibold">Time Left:</span>&nbsp;{count}{" "}
+            seconds
+          </div>
+        )}
+        {state$.quiz.displayQuestion.get() && <DisplayQuestion />}
+        {state$.quiz.waitingForOthers.get() && <WaitingForOtherPlayers />}
+        {state$.quiz.answered.get() && !state$.quiz.waitingForOthers.get() && (
+          <ShowAnswer />
+        )}
+        {!state$.quiz.displayQuestion.get() &&
+          !state$.quiz.waitingForOthers.get() &&
+          !state$.quiz.answered.get() && <WaitingForQuestion />}
+      </div>
     </div>
-    <div className="flex w-full p-2 justify-end">
-      <p className="text-lg">ID: {state$.player.id.get()}</p>
-    </div>
-    <div className="flex flex-col gap-6">
-      {showTimer.get() && <div className="text-2xl text-center">
-        <span className="font-semibold">Time Left:</span>&nbsp;{count} seconds
-      </div>}
-      {state$.quiz.displayQuestion.get() && <DisplayQuestion />}
-      {state$.quiz.waitingForOthers.get() && <WaitingForOtherPlayers />}
-      {
-        state$.quiz.answered.get()
-        && !state$.quiz.waitingForOthers.get()
-        && <ShowAnswer />
-      }
-      {
-        !state$.quiz.displayQuestion.get()
-        && !state$.quiz.waitingForOthers.get()
-        && !state$.quiz.answered.get()
-        && <WaitingForQuestion />
-      }
-    </div>
-  </div>
-)
+  );
 });
 
 export default PlayQuiz;

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,6 +6,7 @@ interface IQuizState {
   answers: Array<string>;
   selectedAnswer: string;
   answered: boolean;
+  correctAnswer: string;
   isAnswerCorrect: boolean;
   waitingForOthers: boolean;
 }
@@ -24,6 +25,7 @@ const defaultQuizState: IQuizState = {
   answers: [],
   selectedAnswer: "",
   answered: false,
+  correctAnswer: "",
   isAnswerCorrect: false,
   waitingForOthers: false,
 };


### PR DESCRIPTION
Componentized the !Toohak header and replaced all instances where there was duplicate code.

Made UI for the ShowAnswer page but had some formatting troubles and kinda just made it a smaller thing than what I had before (previously whole screen was red/green). Since we are calling the ShowAnswer component from the PlayQuiz page, it is confined to the flex elements it is in. If there is an easy way to just ignore all that and fill the entire page, please lmk.

Here is what it looks like right now.
<img width="1278" alt="Screenshot 2024-02-26 010513" src="https://github.com/yesh0907/Toohak-FE/assets/97086113/bf859fd4-d5ab-41eb-b5e8-db43b60e87c0">
Incorrect answer

<img width="1276" alt="Screenshot 2024-02-26 010659" src="https://github.com/yesh0907/Toohak-FE/assets/97086113/7e78aca4-d2e6-410a-ad64-ba8a6e44f25a">
Correct answer (Ignore timer. I just hacked some stuff for the screenshot.)

